### PR TITLE
Add Simple JIRA Activity Stream via Google Feed API.

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -1,5 +1,6 @@
 title: Arquillian
 description: A container-oriented testing framework for writing real integration tests.
+jira_key: ARQ
 github_organization: arquillian
 source_repo: http://github.com/arquillian
 intense_debate_base_url: http://arquillian.org

--- a/code/activity.html.haml
+++ b/code/activity.html.haml
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Activity
+---
+%script{ :type=>'text/javascript', :src=>'/javascripts/jquery.tmpl.js' }
+%script{ :type=>'text/javascript', :src=>'/javascripts/jquery.jgfeed.js' }
+%script{ :id=> 'activity-tmpl', :type=>'text/x-jquery-tmpl'}    
+  %tr
+    %td ${title}
+    
+
+%table#activity.data
+
+:javascript
+  $.jGFeed(encodeURI('http://issues.jboss.org/activity?streams=key+IS+#{site.jira_key}'),
+    function(feeds){
+      if(!feeds){
+        return false;
+      }
+      $('#activity-tmpl').tmpl(feeds.entries).appendTo('#activity');
+    }, 10);

--- a/code/index.html.haml
+++ b/code/index.html.haml
@@ -8,3 +8,5 @@ title: Code Overview
       %a{ :href=> "/module/"} Modules
     %li
       %a{ :href=> "/code/builds/"} Build Status
+    %li
+      %a{ :href=> "/code/activity/"} Activity


### PR DESCRIPTION
Currently very primitive title displayed on code/activity page. This might be possible to expand with email / jira issue links etc using the XML response instead of JSON response from the Google Feed API
