### PR TITLE
Add Lanyrd extension with session Search support

### DIFF
--- a/_ext/lanyrd.rb
+++ b/_ext/lanyrd.rb
@@ -1,0 +1,100 @@
+
+module Awestruct
+  module Extensions
+    module Lanyrd
+    
+      class Search
+        
+        def initialize(term)
+          @base = 'http://lanyrd.com'
+          @term = term
+        end
+      
+        def execute(site)
+          @lanyrd_tmp = tmp(site.tmp_dir, 'lanyrd')
+          
+          search_url = "#{@base}/search/?type=session&q=#{@term}"
+          
+          sessions = []
+          
+          pages = []
+          
+          page1 = Hpricot(getOrCache(File.join(@lanyrd_tmp, "search-#{@term}-1.html"), search_url))
+          pages << page1
+          
+          extract_pages(page1, pages)
+          
+          pages.each do |page|
+            extract_sessions(page, sessions)
+          end
+          
+          site.sessions = sessions
+        end
+        
+        # Find all Pages in a 'root' Page
+        def extract_pages(root, pages)
+          root.search('div[@class*=pagination]') do |p|
+            p.search('li') do |entry|
+              a = entry.at('a')
+              if a
+                pageinated_url = "#{@base}#{a.attributes['href']}"
+            
+                pageX = Hpricot(getOrCache(File.join(@lanyrd_tmp, "search-#{@term}-#{a.inner_text}.html"), pageinated_url))
+                pages << pageX
+              end
+            end
+          end
+        end
+        
+        # Find all sessions in Page
+        def extract_sessions(page, sessions)
+          page.search('li[@class*=s-session]').each do |raw|
+            
+            event_link = raw.search('h3').at('a')
+            
+            session = OpenStruct.new
+            session.title = event_link.inner_text
+            
+            session_detail_url = "#{@base}#{event_link.attributes['href']}"
+            session_detail = Hpricot(getOrCache(File.join(@lanyrd_tmp, "session-#{event_link.attributes['href'].split('/').last}.html"), session_detail_url))
+            
+            session.description = session_detail.search('div[@class*=abstract]').inner_html
+            session.detail_url = session_detail_url
+            
+            raw.search('p[@class*=meta]').each do |meta|
+              type = meta.search('strong').inner_html
+              meta.search('strong').remove()
+              
+              if type.eql? 'Time'
+                if meta.inner_text =~ /(.*[0-9]{4}) ([0-9]+:[0-9]{2}[a-z]{2})-([0-9]+:[0-9]{2}[a-z]{2})/
+                  date = $1
+                  start_time = $2
+                  end_time = $3
+                  
+                  session.start_time = Time.parse "#{date} #{start_time}"
+                  session.end_time = Time.parse "#{date} #{end_time}"
+                end
+              end
+              session.raw_time =  meta.inner_text if type.eql? 'Time'
+              session.event =  meta.inner_text if type.eql? 'Event'
+              session.event_url =  "#{@base}#{meta.at('a').attributes['href']}" if type.eql? 'Event'
+              session.speakers = []
+              
+              if type.eql? 'Speakers'
+                meta.search('a').each do |speaker|
+                  session.speakers <<  speaker.inner_text
+                end
+              end
+              
+            end
+            
+            sessions << session
+          end
+        end
+        
+      end
+      
+    end
+  end
+end
+

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -8,6 +8,7 @@ require 'arquillian'
 require 'arquillian_model'
 require 'posts2'
 require 'guide'
+require 'lanyrd'
 #require 'sassy-buttons'
 
 Awestruct::Extensions::Pipeline.new do
@@ -31,6 +32,8 @@ Awestruct::Extensions::Pipeline.new do
     extension Awestruct::Extensions::Jira::ReleaseNotes.new('ARQ', '12310885')
     extension Awestruct::Extensions::GitHub::Release.new('blog', 'textile', '2010-09-14')
     extension Awestruct::Extensions::Arquillian::JiraVersionPrefix.new
+
+    extension Awestruct::Extensions::Lanyrd::Search.new('arquillian')
 
     extension Awestruct::Extensions::Arquillian::TagInfo.new
     extension Arquillian::Model::Bind.new

--- a/invasion/events.html.haml
+++ b/invasion/events.html.haml
@@ -3,6 +3,21 @@ layout: invasion
 title: Events
 javascripts: [ http://cdn.lanyrd.net/badges/person-v1.min.js ]
 ---
+
+%table
+  - for session in site.sessions
+    %tr
+      %th
+        %a{:href=>"#{session.detail_url}"}=session.title
+      %th #{session.start_time} - #{session.end_time}
+      %th
+        %a{:href=>"#{session.event_url}"}=session.event
+    %tr
+      %td{:colspan=>'3'}=session.speakers.join(', ')
+    %tr
+      %td{:colspan=>'3'}=session.description
+
+
 - speakers = { 'aslakknutsen' => { :name => 'Aslak', :gravatar=>'3f27861ec08730fd02c91fe4129d2668' }, 'mojavelinux' => { :name=>'Dan', :gravatar=>'dcccd96c499963133f7f95e7ffa20c4e' }, 'alrubinger' => { :name => 'Andrew', :gravatar=>'4369758fcee235bebd875f0de34aa42e' } }
 %p Below are a list of upcoming speaking events for the members of the Arquillian team.
 - speakers.each do |username, person|


### PR DESCRIPTION
Takes a search term as the initializer argument

  extension Awestruct::Extensions::Lanyrd::Search.new('arquillian')

The extension does the following:
- Search for the specified term
- Parse result for Pagination and fetch paged results
- Parse all pages for Sessions and fetch Session details

Exposes a Array of OpenStruct objects under site.sessions, each object containing the following properties:
- title -> String
- description -> HTML String
- - Abstract from session detail page
- detail_url -> Full URL String
- - Sessions detail page at Lanyrd
- start_time -> Time
- - Sessions start date and time as Time Object
- end_time -> Time
- - Sessions end date and time as Time Object
- raw_time -> String
- - Unparsed date string
- event -> String
- - Conference name
- event_url -> full URL String
- - Events detail page at Lanyrd
- speakers -> Array of Strings
- \* Speakers full name
