### PR TITLE
Order contributors by number of GitHub Contributions

### DIFF
--- a/_ext/github.rb
+++ b/_ext/github.rb
@@ -85,6 +85,7 @@ module Awestruct
 
         def execute(site)
           github_tmp = tmp(site.tmp_dir, 'github')
+          site.contributors = Hash.new unless site.contributors
 
           site.pages.each do |page|
             if page.github_repo_owner and page.github_repo
@@ -96,6 +97,7 @@ module Awestruct
 
               # Get Contributors User info
               contributor_json.each do |contributor|
+
                 user_json = getOrCacheJSON(File.join(github_tmp, "user-#{contributor['login']}.json"), contributor['url'])
                 contributor['user'] = user_json
 
@@ -109,8 +111,13 @@ module Awestruct
                     end 
                   end
                 end
-                site.contributors = Hash.new unless site.contributors
-                site.contributors[contributor['login'].downcase] = contributor
+                # Contributor allready stored in site, summarize contributions
+                if site.contributors[contributor['login'].downcase]
+                  stored_contrib = site.contributors[contributor['login'].downcase]
+                  stored_contrib['contributions'] = stored_contrib['contributions'] + contributor['contributions'] 
+                elsif
+                  site.contributors[contributor['login'].downcase] = contributor
+                end
               end
 
               page.github_repo_contributors = contributor_json

--- a/_layouts/module.html.haml
+++ b/_layouts/module.html.haml
@@ -12,7 +12,7 @@ layout: default
   ~ content
   %h3 Contributors
   %ul.contributors
-    - for contributor in page.github_repo_contributors.sort{|a,b| a[0].to_s.downcase<=>b[0].to_s.downcase} 
+    - for contributor in page.github_repo_contributors.sort{|a,b| b['contributions']<=>a['contributions']} 
       %li
         .photo
           %img{:src=>contributor['avatar_url'], :title=>contributor['user']['name']}

--- a/community/contributors.html.haml
+++ b/community/contributors.html.haml
@@ -4,7 +4,7 @@ title: Contributors
 ---
 #content
   %ul.contributors
-    - for contributor in site.contributors.sort{|a,b| a[0].to_s.downcase<=>b[0].to_s.downcase} 
+    - for contributor in site.contributors.sort{|a,b| b[1]['contributions'] <=> a[1]['contributions'] } 
       %li
         .photo
           %img{:src=>contributor[1]['avatar_url'], :title=>contributor[1]['user']['name']}


### PR DESCRIPTION
Total Contributions over all Modules
  site.contributors['login']['contributions']

Contributions pr Module
  page.github_repo_contributors[i]['contributions']

Sort order on community/contributors and modules has been updated to take the new field into account
