### PR TITLE
Add Awestruct::Extension::GitHelper helper

### DIFF
--- a/_ext/git_helper.rb
+++ b/_ext/git_helper.rb
@@ -1,0 +1,20 @@
+module Awestruct
+  module Extensions
+    module GitHelper
+
+      def page_authors(page)
+        authors = Hash.new
+        
+        g = Git.open(page.site.dir)
+        g.log(200).object(page.relative_source_path[1..-1]).each{ |x|
+          if authors[x.author.name]
+            authors[x.author.name] = authors[x.author.name] +1
+          elsif
+            authors[x.author.name] = 1
+          end
+        }
+        return authors.sort{|a,b| b[1]<=>a[1]}.map{|x| x[0]}
+      end
+    end
+  end
+end

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -3,6 +3,7 @@ require 'page_debug'
 require 'fork_me_ribbon'
 require 'interwiki'
 require 'github'
+require 'git_helper'
 require 'jira'
 require 'arquillian'
 require 'arquillian_model'
@@ -56,4 +57,6 @@ Awestruct::Extensions::Pipeline.new do
     helper Awestruct::Extensions::ForkMeRibbon
     helper Awestruct::Extensions::Interwiki
     helper Awestruct::Extensions::PageDebug
+
+    helper Awestruct::Extensions::GitHelper
 end

--- a/_layouts/guide.html.haml
+++ b/_layouts/guide.html.haml
@@ -1,6 +1,7 @@
 ---
 layout: guide-base
 ---
+- page.authors = page_authors(page)
 - page.javascripts = [ '/javascripts/jquery-scroll.js', 'http://apis.google.com/js/plusone.js' ]
 #content
   %h2= page.title

--- a/guides/functional_testing_using_drone.textile
+++ b/guides/functional_testing_using_drone.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: Functional Testing using Arquillian Drone
-authors: [Karel Piwko, Dan Allen]
 tags: [drone, selenium, as7, cdi, solder]
 guide_summary: Discover how Arquillian Drone simplifies the use of Selenium to test the web UI of your application.
 guide_group: 2

--- a/guides/getting_started.textile
+++ b/guides/getting_started.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: Getting Started
-authors: [Dan Allen]
 tags: [cdi, weld, maven, forge, eclipse]
 guide_summary: Learn how to add Arquillian to the test suite of your project and write your first Arquillian test.
 guide_group: 1

--- a/guides/getting_started_faster_with_forge.textile
+++ b/guides/getting_started_faster_with_forge.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: Getting Started Faster with Forge
-authors: [Paul Bakker, Lincoln Baxter III]
 guide_summary: Learn how to use JBoss Forge to get started faster with Arquillian and work more efficiently as you develop tests.
 guide_group: 1
 guide_order: 30

--- a/guides/getting_started_rinse_and_repeat.textile
+++ b/guides/getting_started_rinse_and_repeat.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: "Getting Started: Rinse and Repeat"
-authors: [Dan Allen]
 guide_summary: Part 2 of the Getting Started guide. Review your progress by exploring into a slightly more complex example and learn how to use remote containers.
 guide_group: 1
 guide_order: 20

--- a/guides/testing_java_persistence.textile
+++ b/guides/testing_java_persistence.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: Testing Java Persistence
-authors: [Dan Allen]
 tags: [jpa, database, persistence, transactions]
 guide_summary: Test your data! Learn how to test Java Persistence (JPA) queries against multiple providers in an Arquillian test.
 guide_group: 2


### PR DESCRIPTION
One 'tiny' issue with getting them from the git history:
- ANY change to the file counts as author, so Dan and Aslak are authors/co authors of 'all'
- ONLY people that has been a part of the commit are listed, e.g. Karel is missing from the Drone guide since Dan 'copied' it in from jboss.org

It's possible where we have guides that are copied in, to manually add to the page.authors Array i guess..

_layouts
  guide.html.haml: 
  ---
    # meta
  ---
- page.authors = page_authors(page)

guides/
  my_guide.textile: 
  ---
    # meta
  ---
  #{page.authors = ['Karel Piwko'] + page.authors}

  (this does not work with site.interpolate: false)  ??
## Methods

page_authors(page)

Returns a Array of unique author.name's based on the Git commit history located at page.site.dir for the given page.
The Array is ordered by number of commits done by the authors.
