### PR TITLE
Add page_authors(page) method to Awestruct::Extension::Guide

### DIFF
--- a/guides/functional_testing_using_drone.textile
+++ b/guides/functional_testing_using_drone.textile
@@ -1,7 +1,7 @@
 ---
 layout: guide
 title: Functional Testing using Arquillian Drone
-authors: [Karel Piwko, Dan Allen]
+authors: ['Karel Piwko']
 tags: [drone, selenium, as7, cdi, solder]
 guide_summary: Discover how Arquillian Drone simplifies the use of Selenium to test the web UI of your application.
 guide_group: 2

--- a/guides/getting_started.textile
+++ b/guides/getting_started.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: Getting Started
-authors: [Dan Allen]
 tags: [cdi, weld, maven, forge, eclipse]
 guide_summary: Learn how to add Arquillian to the test suite of your project and write your first Arquillian test.
 guide_group: 1

--- a/guides/getting_started_faster_with_forge.textile
+++ b/guides/getting_started_faster_with_forge.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: Getting Started Faster with Forge
-authors: [Paul Bakker, Lincoln Baxter III]
 guide_summary: Learn how to use JBoss Forge to get started faster with Arquillian and work more efficiently as you develop tests.
 guide_group: 1
 guide_order: 30

--- a/guides/getting_started_rinse_and_repeat.textile
+++ b/guides/getting_started_rinse_and_repeat.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: "Getting Started: Rinse and Repeat"
-authors: [Dan Allen]
 guide_summary: Part 2 of the Getting Started guide. Review your progress by exploring into a slightly more complex example and learn how to use remote containers.
 guide_group: 1
 guide_order: 20

--- a/guides/testing_java_persistence.textile
+++ b/guides/testing_java_persistence.textile
@@ -1,7 +1,6 @@
 ---
 layout: guide
 title: Testing Java Persistence
-authors: [Dan Allen]
 tags: [jpa, database, persistence, transactions]
 guide_summary: Test your data! Learn how to test Java Persistence (JPA) queries against multiple providers in an Arquillian test.
 guide_group: 2


### PR DESCRIPTION
Returns a Array of unique author.name's based on the Git commit history located at page.site.dir for the given page.
The Array is ordered by number of commits done by the authors.

page_authors can be used as a Helper via:

   helper Awestruct::Extension::Guide

or if using the Guide extension, it will be used to populate the page.authors/guide.authors objects.

(note: if page.authors exists, the two Arrays will be merged placing page.authors first)
