### PR TITLE
Add create_edit_link helper for generating linkes to github.com edit feature #64

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -13,6 +13,7 @@ resolve_published_artifacts: false
 github_organization: arquillian
 source_repo: https://github.com/arquillian
 website_source_repo: https://github.com/arquillian/arquillian.github.com
+website_source_branch: develop
 speakers_team_id: 146647
 issue_tracker: https://issues.jboss.org/browse/ARQ
 api_docs: http://docs.jboss.org/arquillian/api/latest

--- a/_ext/edit.rb
+++ b/_ext/edit.rb
@@ -1,0 +1,34 @@
+module Awestruct
+  module Extensions
+    module Edit
+
+    	def create_edit_link(page)
+        html = ''
+
+        repo = page.site.website_source_repo
+        branch = page.site.website_source_branch
+        page_source = page.relative_source_path
+        page_source = page_source[1...page_source.length] if page_source[0].eql? '/'
+
+        # Release blog posts has a bit of a different file layout then the original
+        # so if the page_source does not exist, we assume a release page and extract the metadata
+        # instead of using the actual page_source
+        if !File.exists?(page_source)
+          # in  -> blog/2012-01-13-arquillian-testrunner-spock-1-0-0-Alpha1.html
+          # out -> blog/arquillian-testrunner-spock-1.0.0.Alpha1.textile
+          if page_source =~ /(.*)[0-9]{4}\-[0-9]{2}\-[0-9]{2}\-(.*)([0-9].*\-[0-9].*\-[0-9].*)\.html/
+            page_source = "#{$1}#{$2}#{$3.gsub(/\-/, '.')}.textile"
+          end
+        end
+
+        if !File.exists?(page_source)
+          puts "Could not find page source in local repository, can not create edit link for #{page_source}"
+          return '' #not all release pages have a actual page to edit, in that case return nothing
+        end
+
+        edit_url = "#{repo}/edit/#{branch}/#{page_source}"
+        html += %Q(<a href="#{edit_url}">Edit</a>)
+      end
+    end
+  end
+end

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -15,6 +15,7 @@ require_relative 'textile_plus'
 require_relative 'disqus_more'
 require_relative 'posts_helper'
 require_relative 'cache_evolver'
+require_relative 'edit'
 #require_relative 'page_debug'
 #require_relative 'fork_me_ribbon'
 
@@ -77,6 +78,7 @@ Awestruct::Extensions::Pipeline.new do
   helper Awestruct::Extensions::Interwiki
   helper Awestruct::Extensions::GoogleAnalytics
   helper Awestruct::Extensions::CacheEvolver
+  helper Awestruct::Extensions::Edit
   #helper Awestruct::Extensions::ForkMeRibbon
   #helper Awestruct::Extensions::PageDebug
 end

--- a/_layouts/blog.html.haml
+++ b/_layouts/blog.html.haml
@@ -11,6 +11,7 @@ layout: default
     %header.header
       %h2.title
         %a{:href=>page.url}= page.title
+        .edit_link=create_edit_link(page)
       .byline
         %img.avatar{:src=>site.identities.lookup(page.author).avatar_url(44)}
         %span.author<

--- a/_layouts/guide.html.haml
+++ b/_layouts/guide.html.haml
@@ -5,6 +5,7 @@ layout: guide-base
 - page.javascripts = [ '/javascripts/jquery-scroll.js', 'http://apis.google.com/js/plusone.js' ]
 - groups = [['beg', 'First Steps'], ['int', 'More Coverage'], ['adv', 'Enhance']]
 #content{:lang=>page.language ? page.language.code : nil}
+  .edit_link=create_edit_link(page)
   %h2= page.title
   - if page.authors
     .authors<


### PR DESCRIPTION
Generates a 'edit' link for blogs, guides and release notes that link to GitHub online edit feature.

Logged in users with push rights to the site repo can commit directly from this screen while non authorized users will be presented with a open to open a pull request. 

Example: https://github.com/arquillian/arquillian.github.com/edit/develop/blog/2012-03-29-arquillian-project-bridge.textile

NOTE: the button needs styling and positioning :)
