### PR TITLE
LoginScreenSeleniumTest opens the wrong page

### DIFF
--- a/guides/functional_testing_using_drone.textile
+++ b/guides/functional_testing_using_drone.textile
@@ -533,7 +533,7 @@ div(filename). src/test/java/org/arquillian/example/LoginScreenSeleniumTest.java
 bc(prettify).. // clip
 @Test
 public void should_login_successfully() {
-    browser.open(deploymentUrl + "home.jsf");
+    browser.open(deploymentUrl + "login.jsf");
 
     browser.type("id=loginForm:username", "demo");
     browser.type("id=loginForm:password", "demo");


### PR DESCRIPTION
The test opens home.jsf instead of login.jsf - this fails the tests (obviously).
