### PR TITLE
Fixed paths to test-persistence.xml for managed JBoss

### DIFF
--- a/guides/testing_java_persistence.textile
+++ b/guides/testing_java_persistence.textile
@@ -69,7 +69,7 @@ To get you acclimated, here's the directory structure of the project:
 *** resources-glassfish-embedded/
 **** glassfish-resources.xml
 **** test-persistence.xml
-*** resources-jbossas-remote/
+*** resources-jbossas-managed/
 **** test-persistence.xml
 * pom.xml
 
@@ -592,7 +592,7 @@ We can run the exact same test on JBoss AS 7. We'll need a different Persistence
 
 p(warning). %Arquillian doesn't yet support deploying a DataSource to JBoss AS--though it's in the pipeline. For now, we'll use the built-in DataSource in JBoss AS 7, java:jboss/datasources/ExampleDS.%
 
-div(filename). src/test/resources-jbossas-remote/test-persistence.xml
+div(filename). src/test/resources-jbossas-managed/test-persistence.xml
 
 bc(prettify). <?xml version="1.0" encoding="UTF-8"?>
 <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence"

--- a/guides/testing_java_persistence_fr.textile
+++ b/guides/testing_java_persistence_fr.textile
@@ -58,7 +58,7 @@ Afin que vous puissiez prendre vos repères, voici la structure de répertoire d
 *** resources-glassfish-embedded/
 **** glassfish-resources.xml
 **** test-persistence.xml
-*** resources-jbossas-remote/
+*** resources-jbossas-managed/
 **** test-persistence.xml
 * pom.xml
 
@@ -507,7 +507,7 @@ h3. Exécuter le Test (JBoss AS 7)
 
 Nous pouvons exécuter exactement le même test sur JBoss AS 7. Nous aurons besoin d'une unité de persistance différente, qui utilise une ressource JDBC disponible sur JBoss AS et qui positionne quelques paramètres Hibernate. (pour le moment, Arquillian ne supporte pas le déploiement de DataSource dans JBoss AS, même si c'est dans le pipeline ; nous utilisons donc une DataSource intégrée par défaut, java:jboss/datasources/ExampleDS).
 
-div(filename). src/test/resources-jbossas-remote/test-persistenc e.xml
+div(filename). src/test/resources-jbossas-managed/test-persistenc e.xml
 
 bc(prettify). <?xml version="1.0" encoding="UTF-8"?>
 <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence"
@@ -552,7 +552,7 @@ bc(prettify). <!-- clip -->
                 <directory>src/test/resources</directory>
             </testResource>
             <testResource>
-                <directory>src/test/resources-jbossas-remote</directory>
+                <directory>src/test/resources-jbossas-managed</directory>
             </testResource>
         </testResources>
     </build>


### PR DESCRIPTION
Hi,

I fixed the paths to test-persitence.xml in the persistence guide (both in English and French) because they were erroneously leading to test-jbossas-remote instead of test-jbossas-managed in a few places.

Cheers,

Michael
