### PR TITLE
Adjustments for awestructx (awestruct-0.4.2.x2, --pre)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    RedCloth (4.2.9)
     RedCloth (4.2.9-java)
     awestruct (0.2.15)
       RedCloth (~> 4.2.9)
@@ -28,15 +29,18 @@ GEM
       sass (~> 3.1)
     compass-960-plugin (0.10.4)
       compass (>= 0.10.0)
+    ffi (1.0.11)
     ffi (1.0.11-java)
     fssm (0.2.8.1)
     git (1.2.5)
     haml (3.1.4)
     hashery (1.5.0)
       blankslate
+    hpricot (0.8.6)
     hpricot (0.8.6-java)
     jruby-openssl (0.7.6.1)
       bouncy-castle-java (>= 1.5.0146.1)
+    json (1.6.6)
     json (1.6.6-java)
     mime-types (1.18)
     notifier (0.1.4)
@@ -55,6 +59,7 @@ GEM
 
 PLATFORMS
   java
+  ruby
 
 DEPENDENCIES
   awestruct (= 0.2.15)

--- a/_layouts/release.html.haml
+++ b/_layouts/release.html.haml
@@ -1,6 +1,3 @@
----
-layout: post
----
 %p The Arquillian team is proud to announce the <em>#{page.release.version}</em> release of the <em>#{page.component.name}</em> component!
 ~ content
 %h3 What is Arquillian?

--- a/index.html.haml
+++ b/index.html.haml
@@ -109,7 +109,10 @@ body_class: home
                 -#%p= summarize(html_to_text(cut_at ? post.content[0,cut_at] : post.content), 50)
                 - text = html_to_text(cut_at ? post.content[0, cut_at] : post.content)
                 -# might want to use 'white-space: pre-line;' here
-                %p<= text[0..text.index(/[\.\!]( |$)/, [text.index(/[\.\!]( |$)/) + 1, text.length - 1].min)] + '...'
+                - first_sentence = text.index(/[\.\!]( |$)/)
+                - second_sentence = text.index(/[\.\!]( |$)/, [ first_sentence + 1, text.length - 1].min) || text.index(/[ ]/, [ first_sentence + 1, text.length - 1 ].min)
+                - summary = text[0..second_sentence]
+                %p<= summary + '...'
         .more
           %a(href='/blog') View all blog entries &raquo;
       #events


### PR DESCRIPTION
These changes allow the arquillian.org site to be generated using the Next Generation of awestruct, version 0.4.2.x2 or higher.

To use this version of Awestruct, you must gem install using the --pre flag.
