### PR TITLE
Updated link to Graphene guide from features page

### DIFF
--- a/features/index.html.haml
+++ b/features/index.html.haml
@@ -51,7 +51,7 @@ body_class: tour
           %h2 Drive the Browser
           %p Arquillian is just as relevant for client testing as it is for server-side testing. Arquillian Drone abstracts away all the tedious setup of the Selenium Server, letting you skip right to driving the browser from your test. Arquillian even unifies client and server-side testing, most apparent in our JSFUnit integration.
           %p.learn
-            %a(href='/guides/functional_testing_using_drone') Learn to use this feature &raquo;
+            %a(href='/guides/functional_testing_using_graphene') Learn to use this feature &raquo;
         .preview
           %img(src='/images/feature_browser.png')
       %hr


### PR DESCRIPTION
It was pointing to the old Drone guide.

Please update the text which is in the feature page next to "Drive the browser" to contain Graphene related information. Thanks.
