### PR TITLE
Fixed BOM order for Drone

### DIFF
--- a/guides/functional_testing_using_graphene.textile
+++ b/guides/functional_testing_using_graphene.textile
@@ -140,7 +140,7 @@ bc(prettify).. <!-- clip -->
 </dependencyManagement>
 <!-- clip -->
 
-p. Below that @<dependency>@, add another entry for defining the version matrix for Drone and Selenium transitive dependencies, leaving you with the following result:
+p. Above that @<dependency>@, add another entry for defining the version matrix for Drone and Selenium transitive dependencies, leaving you with the following result:
 
 div(filename). pom.xml
 
@@ -148,9 +148,9 @@ bc(prettify).. <!-- clip -->
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>org.jboss.arquillian</groupId>
-            <artifactId>arquillian-bom</artifactId>
-            <version>1.1.1.Final</version>
+            <groupId>org.jboss.arquillian.selenium</groupId>
+            <artifactId>selenium-bom</artifactId>
+            <version>2.35.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -162,9 +162,9 @@ bc(prettify).. <!-- clip -->
             <scope>import</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.selenium</groupId>
-            <artifactId>selenium-bom</artifactId>
-            <version>2.35.0</version>
+            <groupId>org.jboss.arquillian</groupId>
+            <artifactId>arquillian-bom</artifactId>
+            <version>1.1.1.Final</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>


### PR DESCRIPTION
Fixed order for BOM. 

We need to work this better. Arquillian BOM contains a Drone BOM already, which is IMHO wrong. With current setup, we are order dependent for specifying Drone version.

We should either remove Drone from Arquillian BOM - rely on -with-tools BOM here, otherwise we would need to release a Arquillian BOM with every Drone final.

Same for selenium, we currently provide a default value, however we still recommend people to put Selenium BOM in there. We need to be more concise here.
