### PR TITLE
ARQGRA-392: update and enhance Graphene guide

### DIFF
--- a/guides/functional_testing_using_graphene.textile
+++ b/guides/functional_testing_using_graphene.textile
@@ -157,7 +157,7 @@ bc(prettify).. <!-- clip -->
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-drone-bom</artifactId>
-            <version>1.2.0.Beta1</version>
+            <version>1.2.0.Final</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -200,7 +200,7 @@ bc(prettify).. <!-- clip -->
 <dependency>
     <groupId>org.jboss.arquillian.graphene</groupId>
     <artifactId>graphene-webdriver</artifactId>
-    <version>2.0.0.Beta1</version>
+    <version>2.0.0.Final</version>
     <type>pom</type>
     <scope>test</scope>
 </dependency>
@@ -253,10 +253,12 @@ bc(prettify).. <!-- clip -->
 <build>
     <!-- clip -->
     <!-- test resource filtering evaluates ${browser} expression in arquillian.xml -->
-    <testResource>
-        <directory>src/test/resources</directory>
-        <filtering>true</filtering>
-    </testResource>
+    <testResources>
+        <testResource>
+            <directory>src/test/resources</directory>
+            <filtering>true</filtering>
+        </testResource>
+    </testResources>
     <!-- clip -->
 </build>
 <!-- clip -->
@@ -971,6 +973,8 @@ public class LoginPage {
 p. We're using the same mechanism for locating Page Fragments as we used for @WebElement@ fields. The usage of the page fragment in the test is pretty straightforward.
 
 _Arquillian makes integration testing a breeze. Arquillian Graphene adds great support for functional tests. Together, they make developing tests fun again._
+
+h3. Documentation and other useful resources
 
 If you are looking for more Graphene goodness, be sure to check the "Graphene Reference Documentation":https://docs.jboss.org/author/display/ARQGRA2/Home.
 


### PR DESCRIPTION
- Graphene and Drone version upgraded to Final
- <testResource> need to be preceded with <testResources>
- references for Graphene documentation made more explicit
