### PR TITLE
Graphene 2.0.0.Final release notes updates and fixes

### DIFF
--- a/blog/arquillian-graphene-2.0.0.Final.textile
+++ b/blog/arquillian-graphene-2.0.0.Final.textile
@@ -49,11 +49,12 @@ p. Graphene adds to this the concept of Page Fragments, which allows you to make
 
 bc(prettify).. public class UserDetailsPage {
 
-@FindBy(css = “.ui-timepicker”)
-private TimePicker birthday;
+    @FindBy(css = “.ui-timepicker”)
+    private TimePicker birthday;
 
-public void setBirthDay(DateTime date) {
-    birthday.setDate(date);
+    public void setBirthDay(DateTime date) {
+        birthday.setDate(date);
+    }
 }
 
 public void TestCase {
@@ -74,16 +75,16 @@ h4. Testing AJAX
 
 p. Another area where Graphene excels is testing AJAX applications. In fact, Graphene doesn’t consider the WebElement as a concrete element on the target  page, but rather as a proxy (or promise) for the real element that might be.
 
-p. You no longer need to make sure the element you point to is not stale, since the proxy will make sure to bind to the most recent element for the given locator. This allows us to inject all Page Objects and their members using dependency injection during the start phase of the test. Members are then dereferenced as they as used.
+p. You no longer need to make sure the element you point to is not stale, since the proxy will make sure to bind to the most recent element for the given locator. This allows us to inject all Page Objects and their members using dependency injection during the start phase of the test. Members are then dereferenced as they are used.
 
 p. Another cool feature is the Fluent Waiting API, which aims to better the readability of the test code.
 
 p. But even cooler is the use of Request Guards, which allow you to add synchronization points in your test logic when dealing with AJAX communication.
 
-bc(prettify).. @FindBy(jquery = “input:submit”)
+bc(prettify).. @FindByJQuery(“input:submit”)
 private WebElement confirmButton;
 
-@FindBy(jquery = “body div.modal”)
+@FindByJQuery(“body div.modal”)
 private ModalPanel modalPanel;
 
 // waits until a popup is opened
@@ -106,6 +107,7 @@ p. into test objects such as:
 * Arquillian test case (class)
 * Page Objects
 * Page Fragments
+* WebElement wrappers, for example "Select":http://selenium.googlecode.com/git/docs/api/java/org/openqa/selenium/support/ui/Select.html
 
 bc(prettify).. @ArquillianResource
 private WebDriver driver;


### PR DESCRIPTION
- there was old way of JQuery locators
- test case was injected into the page object, it should be other way
  round
