### PR TITLE
ShrinkWrap Resolver 2.2.0 release notes

### DIFF
--- a/blog/resolver-2.2.0.textile
+++ b/blog/resolver-2.2.0.textile
@@ -1,0 +1,38 @@
+---
+date: 2015-09-17
+author: matousjobanek
+---
+
+The most significant change since the last release is postponing of the settings.xml loading.
+Previously, when an user wanted to specify completely different settings.xml:
+
+bc(prettify)..
+Maven.configureResolver().fromFile("path/to/my_settings.xml");
+
+p. during the call @configureResolver()@ the default settings.xml was immediately loaded and later on regenerated with the given @my_settings.xml@. This process could cause an unexpected behavior in some cases (eg. the default settings.xml was corrupted).
+
+
+There in this new release, the loading has been postponed to the time when:
+
+a) the settings.xml is necessarily needed (eg. artifacts resolving)
+or
+b) the resolver is configured with some specific settings.xml (eg. calling @fromFile("path/to/my_settings.xml")@)
+
+So, there is no change for the user in the usage - it just do what the user wants (ie. when some different settings.xml is specified, the default one is never loaded).
+
+
+h3. Significant additions since the last final release 2.1.1:
+
+<i class="icon-star"></i> Gradle importer
+<i class="icon-star"></i> List resolution
+<i class="icon-star"></i> MavenCoordinates as output
+<i class="icon-star"></i> Better cooperation of MavenImporter and IDEs
+<i class="icon-star"></i> Upgrade to Aether 1.0.0.v20140518
+<i class="icon-star"></i> Upgrade to Maven 3.2.5
+
+and many other bugfixes and feature requests. For more information see the release notes of the preceding alpha releases.
+
+
+Big kudos to all contributors who enabled this stable release.
+
+We hope that you'll enjoy our new release and look forward to hear your feedback on the "community forums":#{site.project_space}.


### PR DESCRIPTION
Hi, 
I've released new final release of SWR - version 2.2.0.
It is already in the maven central: http://search.maven.org/#search|ga|1|org.jboss.shrinkwrap.resolver
the tag is pushed in the github: https://github.com/shrinkwrap/resolver/releases
and all jira issues should be  closed: https://issues.jboss.org/projects/SHRINKRES/versions/12325788

If you find some information unnecessary, feel free to change it or remove it altogether :-). Especially the first part related to postponing of the settings.xml loading.

Thanks