### PR TITLE
Updating Forge download link

### DIFF
--- a/guides/getting_started.textile
+++ b/guides/getting_started.textile
@@ -8,7 +8,7 @@ guide_group: 1
 guide_order: 10
 ---
 [forge_home]http://jboss.org/forge
-[forge_download]https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=releases&g=org.jboss.forge&a=forge-distribution&v=1.0.0.Final&e=zip
+[forge_download]https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=releases&g=org.jboss.forge&a=forge-distribution&v=2.20.1.Final&e=zip
 [maven_home]http://maven.apache.org
 [maven_download]http://maven.apache.org/download.html
 [maven_search]http://search.maven.org


### PR DESCRIPTION
Updating Forge download link to current stable version.  The examples appear to use commands from the latest version and do not work on version 1.0.