### PR TITLE
Fixed CDI API version mismatch by updating Java EE 6 to Java EE 7

### DIFF
--- a/guides/getting_started.textile
+++ b/guides/getting_started.textile
@@ -130,7 +130,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. We're going to be writing Java EE 6 components. Therefore, we need to add the Java EE 6 API to the classpath so we can compile these components.
+p. We're going to be writing Java EE 7 components. Therefore, we need to add the Java EE 7 API to the classpath so we can compile these components.
 
 Open up the @pom.xml@ file once again and add the following XML fragment directly inside the @<dependencies>@ element. Here's how the @<dependencies>@ element should look once you're done:
 
@@ -140,8 +140,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -731,8 +731,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -759,7 +759,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. Next, *remove* the @jboss-javaee-6.0@ dependency and the dependencies for the Weld EE embedded container adapter from the main @<dependencies>@ section. Here's how the @<dependencies>@ and @<profiles>@ sections should look when you're done:
+p. Next, *remove* the @jboss-javaee-7.0@ dependency and the dependencies for the Weld EE embedded container adapter from the main @<dependencies>@ section. Here's how the @<dependencies>@ and @<profiles>@ sections should look when you're done:
 
 div(filename). pom.xml
 
@@ -783,8 +783,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -847,8 +847,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started.textile
+++ b/guides/getting_started.textile
@@ -124,7 +124,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -148,13 +148,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %The @org.jboss.spec:jboss-javaee-6.0@ artifact is comprised of only standard Java EE 6 APIs. We *strongly* recommend that you *do not use* the Java EE API artifact with coordinates @javax:javaee-api@. The latter artifact contains classes with stripped method bodies, which will cause your application to throw obscure Absent Code errors if present on the classpath at runtime (even when running tests). "Read this FAQ":https://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode for more details.%
 
 p. The foundation of your project is now ready! Skip to the next section, "Open the Project in Eclipse":#open_the_project_in_eclipse, so we can start writing some code!
 
@@ -217,11 +215,11 @@ By default, Forge sets up the project to use Java 1.6, the minimum recommended v
 
 What we need to add now is the Java EE APIs. That's done using the @project add-dependency@ command below:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:provided:pom
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:provided:pom
 
-You'll also need to add JUnit 4.8, the minimum required version of JUnit to use Arquillian, as a test-scoped dependency:
+You'll also need to add JUnit 4.12, the minimum required version of JUnit to use Arquillian, as a test-scoped dependency:
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 Forge adds the JBoss Community repository to the pom.xml file. This repository is not required to use Arquillian. (However, you can keep it if you are using other libraries only available in the JBoss Community repository). If you do decide to remove the repository, you can easily do so using the following Forge command:
 
@@ -232,42 +230,59 @@ The result of the pom.xml that Forge generates is shown below:
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -768,7 +783,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_de.textile
+++ b/guides/getting_started_de.textile
@@ -126,7 +126,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -150,13 +150,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %Wir empfehlen dringend, dass Du die Java EE API Artefakte mit der groupId @javax:javaee-api@ *nicht verwendest*. Diese Bibliothek enthält Klassen mit verkürzten Methoden, welche dazu führen können, dass bei der Ausführung der Anwendung oder der Tests komische Absent Code Errors erscheinen sobald sich diese Klassen im Classpath befinden. "Mehr dazu in dieser FaQ":http://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode .%
 
 p. Die Grundlagen für Dein Projekt sind jetzt fertig! Überspringe den nächsten Abschnitt und gehe direkt zu "Projekt in Eclipse öffnen":#open_project_in_eclipse damit wir endlich Code schreiben können!
 
@@ -217,61 +215,72 @@ bc(command). [arquillian-tutorial] arquillian-tutorial $
 
 Standardmäßig erstellt Forge Projekte, welche Java 1.6 verwenden. Das passt sehr gut, da dies auch die Minimalanforderung von Arquillian an die Projekte ist.
 
-Nun müssen die Java EE 6 APIs hinzugefügt werden. Das wird mit dem @project add-dependency@ Kommando gemacht:
+Nun müssen die Java EE APIs hinzugefügt werden. Das wird mit dem @project add-dependency@ Kommando gemacht:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:pom:provided
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:pom:provided
 
-Dann fehlt noch JUnit 4.8 für die Tests, als weitere Minimalanforderung von Arquillian.
+Dann fehlt noch JUnit 4.12 für die Tests, als weitere Minimalanforderung von Arquillian.
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 Im Ergebnis sieht die von Forge erzeugte pom.xml dann so aus:
 
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>provided</type>
-            <scope>pom</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
-    <repositories>
-      <repository>
-          <id>JBOSS_NEXUS</id>
-          <url>http://repository.jboss.org/nexus/content/groups/public</url>
-      </repository>
-    </repositories>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -732,7 +741,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_de.textile
+++ b/guides/getting_started_de.textile
@@ -132,7 +132,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. Wir werden Java EE 7 Komponenten schreiben. Daher benötigst Du außerdem die Java EE 6 API als abhängige Bibliothek im Classpath um diese kompilieren zu können.
+p. Wir werden Java EE 7 Komponenten schreiben. Daher benötigst Du außerdem die Java EE 7 API als abhängige Bibliothek im Classpath um diese kompilieren zu können.
 
 Öffne erneut die @pom.xml@ Datei und füge das folgende XML Fragment direkt innerhalb der umschließenden @<dependencies>@ Elemente ein. Das sollte dann so aussehen, wenn Du fertig bist:
 
@@ -142,8 +142,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -695,8 +695,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -723,7 +723,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. Als nächstes *entfernst* Du die @jboss-javaee-6.0@ und die Weld EE Container Adapter Abhängigkeiten aus der Hauptsektion der  @<dependencies>@. Das sollte dann so aussehen, wenn Du fertig bist:
+p. Als nächstes *entfernst* Du die @jboss-javaee-7.0@ und die Weld EE Container Adapter Abhängigkeiten aus der Hauptsektion der  @<dependencies>@. Das sollte dann so aussehen, wenn Du fertig bist:
 
 div(filename). pom.xml
 
@@ -747,8 +747,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -811,8 +811,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_el_gr.textile
+++ b/guides/getting_started_el_gr.textile
@@ -131,7 +131,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. Στη συνέχεια πρόκειται να δημιουργήσουμε Java EE 6 components. Επομένως, χρειάζεται να προσθέσουμε το Java EE 6 API στο classpath ώστε να κάνουμε compile αυτά τα components.
+p. Στη συνέχεια πρόκειται να δημιουργήσουμε Java EE 7 components. Επομένως, χρειάζεται να προσθέσουμε το Java EE 7 API στο classpath ώστε να κάνουμε compile αυτά τα components.
 
 Άνοιξε το @pom.xml@ αρχείο ξανά και πρόσθεσε το ακόλουθο κομμάτι XML μέσα στο @<dependencies>@ element. Αφού το κάνεις αυτό, το @<dependencies>@ element θα πρέπει να είναι όμοιο με το παρακάτω:
 
@@ -141,8 +141,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -731,8 +731,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -759,7 +759,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. Έπειτα, *αφαίρεσε* το @jboss-javaee-6.0@ dependency και τα dependencies για τον Weld EE embedded container adapter από το κύριο @<dependencies>@ element του POM. Μετά από αυτή την αλλαγή, τα @<dependencies>@ και @<profiles>@ τμήματα θα πρέπει να είναι όμοια με τα παρακάτω:
+p. Έπειτα, *αφαίρεσε* το @jboss-javaee-7.0@ dependency και τα dependencies για τον Weld EE embedded container adapter από το κύριο @<dependencies>@ element του POM. Μετά από αυτή την αλλαγή, τα @<dependencies>@ και @<profiles>@ τμήματα θα πρέπει να είναι όμοια με τα παρακάτω:
 
 div(filename). pom.xml
 
@@ -783,8 +783,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -847,8 +847,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_el_gr.textile
+++ b/guides/getting_started_el_gr.textile
@@ -125,7 +125,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -149,13 +149,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %Το @org.jboss.spec:jboss-javaee-6.0@ artifact αποτελείται μόνο από standard Java EE 6 APIs. Συνιστούμε να *μην χρησιμοποιήσεις* το Java EE API artifact με coordinates @javax:javaee-api@. Το τελευταίο artifact περιέχει classes με stripped method bodies, οι οποίες αν υπάρχουν στο classpath κατά το χρόνο εκτέλεσης (ακόμα και κατά την εκτέλεση των tests), θα έχουν ως αποτέλεσμα η εφαρμογή να κάνει throw errors. Για περισσότερες πληροφορίες "Διάβασε το σχετικό κομμάτι στις Συχνές Ερωτήσεις":https://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode.%
 
 p. Ο σκελετός του project είναι έτοιμος! Μετακινήσου στην ενότητα "Άνοιξε το Project στο Eclipse":#open_the_project_in_eclipse, ώστε να γράψουμε λίγο κώδικα!
 
@@ -218,11 +216,11 @@ bc(command). [arquillian-tutorial] arquillian-tutorial $
 
 Στη συνέχεια θα προσθέσουμε τα Java EE APIs.  Αυτό γίνεται με τη χρήση της εντολής @project add-dependency@ παρακάτω:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:provided:pom
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:provided:pom
 
-Επίσης θα χρειαστεί να προσθέσεις το JUnit 4.8, που είναι η ελάχιστη version του JUnit που απαιτείται για την χρήση του Arquillian σαν ένα test-scoped dependency:
+Επίσης θα χρειαστεί να προσθέσεις το JUnit 4.12, που είναι η ελάχιστη version του JUnit που απαιτείται για την χρήση του Arquillian σαν ένα test-scoped dependency:
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 Το Forge προσθέτει το JBoss Community repository στο pom.xml file. Το repository αυτό δεν είναι απαραίτητο για την χρήση του Arquillian. (Ωστόσο, μπορείς να το κρατήσεις αν χρησιμοποιείς άλλα libraries τα οποία είναι διαθέσιμα μόνο μέσω του JBoss Community repository). Στην περίπτωση που αποφασίσεις να αφαιρέσεις το repository, αυτό γίνεται με την παρακάτω απλή Forge εντολή:
 
@@ -233,42 +231,59 @@ bc(command). $ project-remove-repository --url http://repository.jboss.org/nexus
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -768,7 +783,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_es.textile
+++ b/guides/getting_started_es.textile
@@ -125,7 +125,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -149,13 +149,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %Recomendamos e insistimos en *no utilizar* el artefacto del API de Java EE con las coordenadas @javax:javaee-api@. Ese empaquetado contiene clases con métodos a los que se les ha removido el cuerpo, lo que causa que tu aplicación errores referentes a código faltante (Absent Code) si se lo deja en el classpath en tiempo de ejecución (incluso cuando se corren pruebas). "Lee este FAQ":http://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode si quieres conocer los antecedentes.%
 
 p. La base de tu proyecto está lista! Salta a la siguiente sección para "abrir el proyecto en Eclipse":#open_project_in_eclipse para poder empezar a escribir un poco de código!
 
@@ -217,59 +215,70 @@ Por defecto, Forge configura el proyecto para utilizar Java 1.6, la versión mí
 
 Ahora necesitamos agregar los APIs Java EE. Esto se hace utilizando el comando @project add-dependency@ como se muestra a continuación:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:pom:provided
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:pom:provided
 
-Además vas a necesitar agregar JUnit 4.8, la versión mínima requerida de JUnit para utilizar Arquillian, como una dependencia con scope en test:
+Además vas a necesitar agregar JUnit 4.12, la versión mínima requerida de JUnit para utilizar Arquillian, como una dependencia con scope en test:
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 El pom.xml resultante que genera Forge se muestra a continuación:
 
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>provided</type>
-            <scope>pom</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
-    <repositories>
-      <repository>
-          <id>JBOSS_NEXUS</id>
-          <url>http://repository.jboss.org/nexus/content/groups/public</url>
-      </repository>
-    </repositories>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -728,7 +737,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_es.textile
+++ b/guides/getting_started_es.textile
@@ -131,7 +131,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. En esta guía, estaremos escribiendo componentes Java EE 6. Por lo tanto, también vamos a necesitar añadir el API de Java EE 6 a las dependencias para poder compilar estos componentes.
+p. En esta guía, estaremos escribiendo componentes Java EE 7. Por lo tanto, también vamos a necesitar añadir el API de Java EE 7 a las dependencias para poder compilar estos componentes.
 
 Abre el archivo @pom.xml@ nuevamente y agrega el siguiente pedazo de XML directamente dentro del elemento @<dependencies>@. Así es como debe lucir la sección una vez que hayas terminado:
 
@@ -142,7 +142,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>org.jboss.spec</groupId>
         <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -691,8 +691,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -719,7 +719,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. A continuación, *elimina* la dependencia a @jboss-javaee-6.0@ y las dependencias para el adaptador de Weld EE embebido de la seccion principal de @<dependencies>@. Así es como deberían verse las secciones @<dependencies>@ y @<profiles>@ una vez que hayas terminado:
+p. A continuación, *elimina* la dependencia a @jboss-javaee-7.0@ y las dependencias para el adaptador de Weld EE embebido de la seccion principal de @<dependencies>@. Así es como deberían verse las secciones @<dependencies>@ y @<profiles>@ una vez que hayas terminado:
 
 div(filename). pom.xml
 
@@ -743,8 +743,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -807,8 +807,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_fr.textile
+++ b/guides/getting_started_fr.textile
@@ -132,7 +132,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. Nous serons amenés à écrire des composants Java EE 6. Donc, nous aurons sûrement besoin d'ajouter l'API Java EE 6 dans le classpath pour pouvoir compiler ces composants.
+p. Nous serons amenés à écrire des composants Java EE 7. Donc, nous aurons sûrement besoin d'ajouter l'API Java EE 7 dans le classpath pour pouvoir compiler ces composants.
 
 Ouvrez à nouveau le fichier @pom.xml@ et ajoutez le fragment XML ci dessous directement sous le tag @<dependencies>@.
 
@@ -142,8 +142,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -692,8 +692,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -720,7 +720,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. Ensuite *retirez* les dépendances @jboss-javaee-6.0@ et celles pour l'adaptateur Weld EE embarqué de la section @<dependencies>@ principale. Voici à quoi les sections  @<dependencies>@ et @<profiles>@ doivent ressembler lorsque vous avez fini :
+p. Ensuite *retirez* les dépendances @jboss-javaee-7.0@ et celles pour l'adaptateur Weld EE embarqué de la section @<dependencies>@ principale. Voici à quoi les sections  @<dependencies>@ et @<profiles>@ doivent ressembler lorsque vous avez fini :
 
 div(filename). pom.xml
 
@@ -744,8 +744,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -808,8 +808,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_fr.textile
+++ b/guides/getting_started_fr.textile
@@ -126,7 +126,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -150,13 +150,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %Nous vous recommandons vivement de *ne pas utiliser* @javax:javaee-api@ comme artefact pour les API Java EE 6. Cet artefact contient des classes comportant des méthodes dont le code a été retiré, ce qui provoque des erreurs étranges liées à l'absence du code au runtime (même si vous n'exécutez que des tests). "Pour plus d'information reportez vous à cette FAQ":http://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode.%
 
 p. Le squelette de votre projet est maintenant prêt ! Allez directement à la section "ouvrir le projet dans eclipse":#open_project_in_eclipse pour écrire un peu du code !
 
@@ -218,59 +216,70 @@ Par défaut, Forge configure votre projet pour utiliser Java 1.6, qui est la ver
 
 Nous avons maintenant besoin d'ajouter les APIs Java EE en utilisant la commande @project add-dependency@ comme suit:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:pom:provided
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:pom:provided
 
-Vous aurez aussi besoin d'ajouter JUnit 4.8, la version minimale pour utiliser Arquillian. Cette dépendance doit, bien entendu, être en scope test.
+Vous aurez aussi besoin d'ajouter JUnit 4.12, la version minimale pour utiliser Arquillian. Cette dépendance doit, bien entendu, être en scope test.
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 Forge a alors généré le pom.xml suivant:
 
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>provided</type>
-            <scope>pom</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
-    <repositories>
-      <repository>
-          <id>JBOSS_NEXUS</id>
-          <url>http://repository.jboss.org/nexus/content/groups/public</url>
-      </repository>
-    </repositories>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -729,7 +738,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_it.textile
+++ b/guides/getting_started_it.textile
@@ -125,7 +125,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -149,13 +149,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %L'artifact @org.jboss.spec:jboss-javaee-6.0@ contiene soltanto le API standard di Java EE 6. Raccomandiamo *fortemente* di *non usare* l'artifact delle API Java EE con coordinate @javax:javaee-api@. L'ultimo artifact contiene classi con il corpo dei metodi ridotto all'osso, le quali causano all'applicazione errori di codice assente se aggiunte a runtime nel classpath (perfino durante l'esecuzione dei test). "Leggete queste FAQ":https://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode per più dettagli.%
 
 p. La base del progetto è pronta! Saltiamo alla sezione, "Aprire il Progetto con Eclipse":#open_the_project_in_eclipse, in modo da iniziare a scrivere codice!
 
@@ -218,11 +216,11 @@ Per default, Forge configura il progetto con Java 1.6, la versione minima di Jav
 
 Bisogna ora aggiungere le API di Java EE. Viene fatto tramite il comando @project add-dependency@ mostrato qui in basso:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:provided:pom
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:provided:pom
 
-Bisogna anche aggiungere la dipendenza di JUnit 4.8, la versione minima richiesta da Arquillian, con scope di tipo test:
+Bisogna anche aggiungere la dipendenza di JUnit 4.12, la versione minima richiesta da Arquillian, con scope di tipo test:
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 Forge aggiunge il repository della Community JBoss nel file pom.xml. Questo repository non è indispensabile per Arquillian. (E' preferibile comunque mantenerlo se si necessitano altre librerie della Community JBoss). Se si vuole rimuovere il repository, è sufficiente usare il seguente comando di Forge:
 
@@ -233,42 +231,59 @@ Il risultato del pom.xml generato da Forge è mostrato qui in basso:
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -767,7 +782,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_it.textile
+++ b/guides/getting_started_it.textile
@@ -131,7 +131,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. Iniziamo ora a scrivere i componenti Java EE 6. Abbiamo quindi bisogno di aggiungere le API Java EE 6 al classpath in modo da poterle compilare.
+p. Iniziamo ora a scrivere i componenti Java EE 7. Abbiamo quindi bisogno di aggiungere le API Java EE 7 al classpath in modo da poterle compilare.
 
 Apriamo nuovamente il file @pom.xml@ e aggiungiamo il seguente frammento XML direttamente dentro l'elemento @<dependencies>@. Qui in basso vediamo come dovrebbe diventare l'elemento @<dependencies>@ una volta terminato:
 
@@ -141,8 +141,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -730,8 +730,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -758,7 +758,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. *Rimuoviamo* poi la dependency @jboss-javaee-6.0@ e le altre dependency legate al Weld EE embedded container adapter dalla sezione @<dependencies>@. Una volta rimosse, le sezioni @<dependencies>@ e @<profiles>@ risulteranno simili al codice qui in basso:
+p. *Rimuoviamo* poi la dependency @jboss-javaee-7.0@ e le altre dependency legate al Weld EE embedded container adapter dalla sezione @<dependencies>@. Una volta rimosse, le sezioni @<dependencies>@ e @<profiles>@ risulteranno simili al codice qui in basso:
 
 div(filename). pom.xml
 
@@ -782,8 +782,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -846,8 +846,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_ja.textile
+++ b/guides/getting_started_ja.textile
@@ -131,7 +131,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. これからJava EE 6コンポーネントを書きます。そのため、Java EE 6 APIをクラスパスに追加する必要があります。そうすれば、これらのコンポーネントをコンパイルできます。
+p. これからJava EE 7コンポーネントを書きます。そのため、Java EE 7 APIをクラスパスに追加する必要があります。そうすれば、これらのコンポーネントをコンパイルできます。
 
 @pom.xml@ ファイルをもう一度開き、そのXMLフラグメントを @<dependencies>@ 要素の下に追加してください。 @<dependencies>@ 要素追加後は、以下のようになります：
 
@@ -141,8 +141,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -731,8 +731,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -759,7 +759,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. 次に、 @jboss-javaee-6.0@ への依存とWeld EEエンベデッドコンテナアダプタへの依存をメインの @<dependencies>@ セクションから *削除します* 。編集後に、 @<dependencies>@ と @<profiles>@ セクションがどうなっているかを以下に示します：
+p. 次に、 @jboss-javaee-7.0@ への依存とWeld EEエンベデッドコンテナアダプタへの依存をメインの @<dependencies>@ セクションから *削除します* 。編集後に、 @<dependencies>@ と @<profiles>@ セクションがどうなっているかを以下に示します：
 
 div(filename). pom.xml
 
@@ -783,8 +783,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -847,8 +847,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_ja.textile
+++ b/guides/getting_started_ja.textile
@@ -125,7 +125,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -149,13 +149,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %@org.jboss.spec:jboss-javaee-6.0@ アーティファクトは、Java EE 6 APIだけで構成されています。Java EE APIアーティファクトを、 @javax:javaee-api@ と組み合わせて *使わないことを強く* おすすめします。後者のアーティファクトには、メソッドの実装を省いたクラスが含まれているので、実行時に（テストの実行時でも）これがクラスパスに残っていた場合、アプリケーションは奇妙なAbsent Codeエラーを投げます。もっと背景を知りたい場合は、 "このFAQを読んでください":http://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode 。%
 
 p. プロジェクトの基本は準備できました！ "プロジェクトをEclipseで開く":#open_the_project_in_eclipse に進んでください。コードを書きはじめます！
 
@@ -218,11 +216,11 @@ bc(command). [arquillian-tutorial] arquillian-tutorial $
 
 次に追加する必要があるのは、Java EE APIです。以下の @project add-dependency@ コマンドでできます：
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:provided:pom
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:provided:pom
 
-また、Arquillianが最低限要求するバージョンである、JUnit 4.8をテストスコープの依存性として追加する必要があります：
+また、Arquillianが最低限要求するバージョンである、JUnit 4.12をテストスコープの依存性として追加する必要があります：
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 Forgeは、JBoss Communityリポジトリをpom.xmlファイルに追加します。このリポジトリはArquillianに関しては不要です。（しかし、JBoss Commuityリポジトリにしかない他のライブラリを利用しているならば、残しておくこともできます。）リポジトリを削除すると決めれば、以下のForgeのコマンドで簡単に実行できます：
 
@@ -233,42 +231,59 @@ Forgeが生成したpom.xmlを以下に示します：
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>pom</type>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -768,7 +783,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_nl.textile
+++ b/guides/getting_started_nl.textile
@@ -136,7 +136,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. We gaan Java EE 6 componenten schrijven, daarom moeten we Java EE 6 API aan het classpath toevoegen zodat we deze componenten kunnen compileren.
+p. We gaan Java EE 7 componenten schrijven, daarom moeten we Java EE 7 API aan het classpath toevoegen zodat we deze componenten kunnen compileren.
 
 Open de @pom.xml@ nog een keer en voeg het volgende XML fragment toe aan het @<dependencies>@ element. Zo zou het er uit moeten zien wanneer je klaar bent:
 
@@ -146,8 +146,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -697,8 +697,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -725,7 +725,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. Nu, *verwijder* de @jboss-javaee-6.0@ dependency en de dependencies voor de Weld EE container adapter van de @<dependencies>@ sectie. Zo zouden je @<dependencies>@ en @<profiles>@ er uit moeten zien wanneer je klaar bent:
+p. Nu, *verwijder* de @jboss-javaee-7.0@ dependency en de dependencies voor de Weld EE container adapter van de @<dependencies>@ sectie. Zo zouden je @<dependencies>@ en @<profiles>@ er uit moeten zien wanneer je klaar bent:
 
 div(filename). pom.xml
 
@@ -749,8 +749,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -813,8 +813,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_nl.textile
+++ b/guides/getting_started_nl.textile
@@ -130,7 +130,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -154,7 +154,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
@@ -222,59 +222,70 @@ De standaard instelling van Forge is dat Java 1.6 gebruikt wordt de minimum nodi
 
 Wat we nu toe moeten voegen zijn de Java EE APIs, dat doet men door het volgende @project add-dependency@ commando uit te voeren:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:pom:provided
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:pom:provided
 
-Ook dient JUnit minimum versie 4.8 toegevoegd te worden met scope test:
+Ook dient JUnit minimum versie 4.12 toegevoegd te worden met scope test:
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 Het resultaat van de pom dat Forge genereerd is het volgende:
 
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>provided</type>
-            <scope>pom</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
-    <repositories>
-      <repository>
-          <id>JBOSS_NEXUS</id>
-          <url>http://repository.jboss.org/nexus/content/groups/public</url>
-      </repository>
-    </repositories>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -734,7 +745,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_pl.textile
+++ b/guides/getting_started_pl.textile
@@ -131,7 +131,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. Będziemy pisać komponenty Java EE 6, a więc musimy również dodać Java EE 6 API. W przeciwnym wypadku nie moglibyśmy ich kompilować.
+p. Będziemy pisać komponenty Java EE 7, a więc musimy również dodać Java EE 7 API. W przeciwnym wypadku nie moglibyśmy ich kompilować.
 
 W tym celu otwórz ponownie @pom.xml@ i dodej następujący fragment w sekcji @<dependencies>@. Poniżej możesz zobaczyć jak to powinno wyglądać:
 
@@ -141,8 +141,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -691,8 +691,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -719,7 +719,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. Następnie *usuńmy* @jboss-javaee-6.0@ oraz Weld EE Embedded zdefiniowane bezpośrednio w @<dependencies>@. Oto jak powinno to wyglądać finalnie;
+p. Następnie *usuńmy* @jboss-javaee-7.0@ oraz Weld EE Embedded zdefiniowane bezpośrednio w @<dependencies>@. Oto jak powinno to wyglądać finalnie;
 
 div(filename). pom.xml
 
@@ -743,8 +743,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -807,8 +807,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_pl.textile
+++ b/guides/getting_started_pl.textile
@@ -125,7 +125,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -149,13 +149,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %Stanowczo *odradzamy Ci korzystanie* z artefaktu Java EE API @javax:javaee-api@. Zawiera on klasy z metodami, które nie posiadają implementacji. Doprowadzić to może do pojawienia się błędów typu "Absent Code" w trakcie działania Twojej aplikacji. Stanie się tak jeśli artefakt ten będzie dostępny podczas jej działania (nawet w trakcie uruchamiania testów). "Przeczytaj ten poradnik":http://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode jeśli chcesz wiedzieć więcej na ten temat.%
 
 p. Szkielet Twojego projektu jest już gotowy! Omiń następną sekcję i przejdź od razu do "otwórz projekt w Eclipse":#open_project_in_eclipse. Czas zacząć pisać kod!
 
@@ -217,59 +215,70 @@ Miłym udogodnieniem Forge jest domyślne ustawienie Java 1.6 dla stworzonego pr
 
 To czego teraz potrzebujemy, to API platformy Java EE. Wystarczy użyć do tego polecenia @project add-dependency@:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:pom:provided
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:pom:provided
 
-Będziemy potrzebować także JUnit 4.8, ponownie minimalną wersję wymaganą przez Arquilliana, jako zależność w zakresie testowym:
+Będziemy potrzebować także JUnit 4.12, ponownie minimalną wersję wymaganą przez Arquilliana, jako zależność w zakresie testowym:
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 W rezultacie otrzymamy plik pom.xml, który został wygenerowany przez Forge. Wygląda on następująco:
 
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>provided</type>
-            <scope>pom</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
-    <repositories>
-      <repository>
-          <id>JBOSS_NEXUS</id>
-          <url>http://repository.jboss.org/nexus/content/groups/public</url>
-      </repository>
-    </repositories>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -728,7 +737,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/guides/getting_started_pt.textile
+++ b/guides/getting_started_pt.textile
@@ -131,7 +131,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. Vamos escrever componentes Java EE 6, portanto para que possamos compilar nossos componentes, devemos adicionar também a sua API ao nosso classpath.
+p. Vamos escrever componentes Java EE 7, portanto para que possamos compilar nossos componentes, devemos adicionar também a sua API ao nosso classpath.
 
 Abra novamente o arquivo @pom.xml@ e adicione as seguintes dependências dentro do elemento @<dependencies>@. Sua sessão de dependências deverá ficar assim:
 
@@ -141,8 +141,8 @@ bc(prettify).. <!-- clip -->
 <dependencies>
     <dependency>
         <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>1.0.0.Final</version>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <version>1.0.3.Final</version>
         <type>pom</type>
         <scope>provided</scope>
     </dependency>
@@ -729,8 +729,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -757,7 +757,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. Agora, *remova* a dependência com @jboss-javaee-6.0@ e as dependências relacionadas ao container Weld EE da sessão principal de dependências @<dependencies>@. As suas sessões @<dependencies>@ e @<profiles>@ deverão ficar assim:
+p. Agora, *remova* a dependência com @jboss-javaee-7.0@ e as dependências relacionadas ao container Weld EE da sessão principal de dependências @<dependencies>@. As suas sessões @<dependencies>@ e @<profiles>@ deverão ficar assim:
 
 div(filename). pom.xml
 
@@ -781,8 +781,8 @@ bc(prettify).. <!-- clip -->
         <dependencies>
             <dependency>
                 <groupId>org.jboss.spec</groupId>
-                <artifactId>jboss-javaee-6.0</artifactId>
-                <version>1.0.0.Final</version>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.3.Final</version>
                 <type>pom</type>
                 <scope>provided</scope>
             </dependency>
@@ -845,8 +845,8 @@ bc(prettify).. <!-- clip -->
     <dependencies>
         <dependency>
             <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
+            <artifactId>jboss-javaee-7.0</artifactId>
+            <version>1.0.3.Final</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/guides/getting_started_pt.textile
+++ b/guides/getting_started_pt.textile
@@ -125,7 +125,7 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -149,13 +149,11 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
 </dependencies>
 <!-- clip -->
-
-p(important). %O artefato @org.jboss.spec:jboss-javaee-6.0@ é composto pelas APIs padrões do Java EE 6. Recomendamos que você *não use* os artefatos Java EE do grupo @javax:javaee-api@. Esse pacote contém classes com métodos vazios o que poderá fazer com que sua aplicação lance exceções estranhas relacionadas à ausência de código, se forem deixadas no seu classpath em tempo de execução(mesmo quando rodar testes). "Leia esse FAQ":http://community.jboss.org/wiki/WhatsTheCauseOfThisExceptionJavalangClassFormatErrorAbsentCode se você quiser se aprofundar nesse assunto.%
 
 p. A fundação do seu projeto está pronta! Pule para a próxima sessão, "Abra seu projeto no Eclipse":#open_project_in_eclipse, para que possamos começar a escrever código!
 
@@ -218,11 +216,11 @@ Por padrão, o Forge seta o projeto para usar Java 1.6, convenientemente, a vers
 
 Precisamos agora adicionar as API's do Java EE 6. Isso pode ser feito usando o comando @project add-dependency@ como mostrado abaixo:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:pom:provided
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.3.0.Final:pom:provided
 
-Você também precisará adicionar uma dependência com o JUnit 4.8 em escopo de testes:
+Você também precisará adicionar uma dependência com o JUnit 4.12 em escopo de testes:
 
-bc(command). $ project-add-dependencies junit:junit:4.8.1:test
+bc(command). $ project-add-dependencies junit:junit:4.12:test
 
 O Forge adiciona o repositório do JBoss Community no arquivo pom.xml. Esse repositorio não é necessário para usar o Arquillian. (No entanto, você pode manté-lo se você estiver usando outras bibliotecas disponíveis apenas no repositório do JBoss Community). Se você decidir remover o repositório, você pode fazé-lo facilmente usando o seguinte comando do Forge:
 
@@ -233,42 +231,59 @@ O resultado é o pom.xml gerado pelo Forge e mostrado a seguir:
 div(filename). pom.xml
 
 bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="
-        http://maven.apache.org/POM/4.0.0
-        http://maven.apache.org/xsd/maven-4.0.0.xsd"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.arquillian.example</groupId>
-    <artifactId>arquillian-tutorial</artifactId>
+    <groupId>org.arquillian.tutorial.new</groupId>
+    <artifactId>arquillian-tutorial-new</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.spec</groupId>
+          <artifactId>jboss-javaee-7.0</artifactId>
+          <version>1.0.3.Final</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.jboss.spec</groupId>
-            <artifactId>jboss-javaee-6.0</artifactId>
-            <version>1.0.0.Final</version>
-            <type>provided</type>
-            <scope>pom</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>org.jboss.spec</groupId>
+        <artifactId>jboss-javaee-7.0</artifactId>
+        <type>pom</type>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
     <build>
-        <finalName>arquillian-tutorial</finalName>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-        </plugins>
+      <finalName>arquillian-tutorial</finalName>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <failOnMissingWebXml>false</failOnMissingWebXml>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
 </project>
 
@@ -766,7 +781,7 @@ bc(prettify).. <!-- clip -->
     <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixed conflicts for weld. Weld required version CDI 1.1 or better. CDI 1.0 API detected due to Java EE6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian.github.com/337)
<!-- Reviewable:end -->
