### PR TITLE
Update Awestruct URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@
 This repository contains the source of the Arquillian website (hosted using http://pages.github.com[github pages]), to which the http://arquillian.org[arquillian.org]
 hostname resolves.
 
-The website is built using http://awestruct.org[Awestruct]. The develop branch contains the unprocessed website source. From that content, Awestruct generates a static website under the `_site` directory. The website is published to the public site by pushing the contents of the `_site` directory to the master branch.
+The website is built using https://awestruct.github.io[Awestruct]. The develop branch contains the unprocessed website source. From that content, Awestruct generates a static website under the `_site` directory. The website is published to the public site by pushing the contents of the `_site` directory to the master branch.
 
 == Setting Up
 

--- a/_layouts/base.html.haml
+++ b/_layouts/base.html.haml
@@ -67,7 +67,7 @@
             Copyright 2009-#{DateTime.now.year} Red Hat, Inc.
             %br
             %i.icon-fire
-            Mixed with <a href="http://twitter.github.com/bootstrap">Bootstrap</a>. Baked by <a href="http://awestruct.org">Awestruct</a>.
+            Mixed with <a href="http://twitter.github.com/bootstrap">Bootstrap</a>. Baked by <a href="https://awestruct.github.io">Awestruct</a>.
             %br
             %i.icon-share-alt
             Website and docs licensed under <a href="http://creativecommons.org/licenses/by/3.0/">CC BY 3.0</a>.
@@ -105,9 +105,6 @@
           .follow-us
             %h4 Stay Informed
             %ul
-              %li
-                %a(href='https://plus.google.com/100660127586085393031?rel=author')<
-                  %img(src='/images/social/googleplus-16.png' alt='Google+' title='Follow Arquillian on Google+')
               %li
                 %a(href='https://twitter.com/#!/search/%23arquillian')<
                   %img(src='/images/social/twitter-16.png' alt='Twitter' title='Browse the #arquillian hashtag on Twitter')

--- a/blog/2012-03-29-arquillian-project-bridge.textile
+++ b/blog/2012-03-29-arquillian-project-bridge.textile
@@ -49,7 +49,7 @@ h3. What's inside
 Before I close, I want to mention some key highlights of the website. Then, I'll leave you to explore and discover the rest :)
 
 * All content managed in git and hosted on Github
-* Baked with "Awestruct":http://awestruct.org, a static site generator
+* Baked with "Awestruct":https://awestruct.github.io, a static site generator
 * A data curating pipeline written in Ruby (JRuby) as Awestruct extensions
 * Pages written in Haml (with a mix of Textile)
 * Easy to read, step-by-step guides (written in Textile, changelog retrieved via git)


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
The domain used here for Awestruct documentation was taken over and promotes online gambling now. The new home of Awestruct documentation is https://awestruct.github.io (c.f. https://github.com/awestruct/awestruct/issues/560)

#### Changes proposed in this pull request:

- update links to Awestruct documentation
- remove link to Google+

