### PR TITLE
fix the ref_guide url to https://docs.jboss.org/author/display/ARQ/Home.html

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -32,7 +32,7 @@ prod_url: http://arquillian.org
 speakers_team_id: 146647
 issue_tracker: https://issues.jboss.org/browse/ARQ
 api_spi_docs: http://docs.jboss.org/arquillian/aggregate/latest
-ref_guide: https://docs.jboss.org/author/display/ARQ/Reference+Guide
+ref_guide: https://docs.jboss.org/author/display/ARQ/Home.html
 project_space: http://community.jboss.org/en/arquillian
 faqs: http://community.jboss.org/en/arquillian/faq
 migration_guides: http://community.jboss.org/wiki/ArquillianMigrationGuides


### PR DESCRIPTION
The ref_guide url (https://docs.jboss.org/author/display/ARQ/Reference+Guide) is broken, so fix it to point to https://docs.jboss.org/author/display/ARQ/Home.html