### PR TITLE
Fixes for the Roq branch

### DIFF
--- a/content/guides/getting-started/getting_started.md
+++ b/content/guides/getting-started/getting_started.md
@@ -41,7 +41,7 @@ The recommended way you create a new Maven project is to Generate a project from
 
 > [INFO] If you already have a Maven project, you can use this section as review to ensure you have the proper dependencies before moving on.
 
-#### Generate a Project from a Maven Archetype {#generate_project_from_archetype}
+#### Generate a Project from a Maven Archetype
 
 First, create a Maven-based Java project using the following command:
 
@@ -241,7 +241,7 @@ Once again open up the `pom.xml` file at the root of the project in your editor.
         <dependency>
             <groupId>org.jboss.arquillian</groupId>
             <artifactId>arquillian-bom</artifactId>
-            <version>#{site.components['arquillian-core'].latest_version}</version>
+            
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/content/guides/workaround-index.md
+++ b/content/guides/workaround-index.md
@@ -2,6 +2,7 @@
 title: Guides
 description: Step-by-step guides to help you get started with Arquillian
 layout: page
+link: guides
 ---
 
 # Arquillian Guides

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Site configuration
-site.url=https://arquillian.org
+%prod.site.url=https://arquillian.org
 
 # Theme configuration
 site.page-layout=default

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -60,7 +60,7 @@ body_class: home
         </div>
     </header>
     
-    {#insert content}No Content!{/}
+    {#insert}No Content!{/}
     
     <footer>
         <div class="container">

--- a/templates/layouts/blog.html
+++ b/templates/layouts/blog.html
@@ -1,10 +1,9 @@
 ---
 layout: default
 ---
-{#main}
 
 <div id="content">
-    {#insert content}{/insert}
+    {#insert /}
 </div>
 <aside id="sidebar" role="complementary">
     {#if !site.collections.posts}
@@ -37,4 +36,3 @@ layout: default
         </ul>
     </nav>
 </aside>
-{/main}

--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -6,6 +6,6 @@ author: Arquillian Project
 ---
 <div id="main" role="main">
     <div class="container">
-        {#insert main}No main{/}
+        {#insert/}
     </div>
 </div>

--- a/templates/layouts/guide-base.html
+++ b/templates/layouts/guide-base.html
@@ -1,9 +1,8 @@
 ---
 layout: default
 ---
-{#main}
 <div id="content" class="guide">
-    {#insert content}{/insert}
+    {#insert /}
 </div>
 <aside id="sidebar" role="complementary">
     <div class="contribute">
@@ -16,4 +15,3 @@ layout: default
         </p>
     </div>
 </aside>
-{/main}

--- a/templates/layouts/guide.html
+++ b/templates/layouts/guide.html
@@ -37,7 +37,7 @@ translators: []
 </div>
 
 <div class="guide-content">
-    {page.rawContent}
+    {#insert /}
 </div>
 
 {/content}

--- a/templates/layouts/index.html
+++ b/templates/layouts/index.html
@@ -1,7 +1,7 @@
 ---
 layout: base
 ---
-{#content}
+
 <div id="main" role="main" class="home">
     <div id="intro">
         <div class="container">
@@ -52,4 +52,3 @@ layout: base
         </div>
     </div>
 </div>
-{/content}

--- a/templates/layouts/invasion.html
+++ b/templates/layouts/invasion.html
@@ -3,7 +3,6 @@ layout: default
 keywords: none
 body_class: invasion
 ---
-{#content}
 <div id="main" role="main" class="invasion">
     <div id="content-header">
         <div class="container">
@@ -16,4 +15,3 @@ body_class: invasion
         </div>
     </div>
 </div>
-{/content}

--- a/templates/layouts/page.html
+++ b/templates/layouts/page.html
@@ -2,8 +2,6 @@
 layout: default
 author: Arquillian Project
 ---
-{#content}
 <div id="content" class="page">
     {#insert /}
 </div>
-{/content}

--- a/templates/layouts/post.html
+++ b/templates/layouts/post.html
@@ -4,11 +4,4 @@ body_class: blog
 title_link: /blog/
 title: Arquillian Blog
 ---
-{#insert content}
-{#if !page.description}
-{#set page.description=site.pageContent(page).split("\n")[0]}
-{/if}
-
-{#include partials/post.html post=page include_comments=true /}
-
-{/insert}
+{#insert /}


### PR DESCRIPTION
It was a bit messy, but it helped me identify some issues in Roq. I’ve made changes, and it now starts properly.

## Changes made

- `page.rawContent` should be used only for indexing/processing (e.g., search, generated description). I’ll add a warning in the docs.  
- Use `{page.description ?: page.contentAbstract}` to generate an abstract if the page doesn’t define one.  
- You can use the default `{#insert /}` instead of a named one—names are only needed for multiple parts, and this improves readability.  
- Don’t set `site.url` in dev mode.  
- You can’t set a variable inside an `if` in the template; use [@TemplateExtension](https://iamroq.com/docs/basics/#template-extensions) for logic instead.  

For duplicate files: this was caused by a bug with indexing parent directories. A fix will be released later today. Meanwhile, I added a temporary workaround (`workaround-index.md`).